### PR TITLE
The dashboard is now open to the public Internet.

### DIFF
--- a/source/dashboard.rst
+++ b/source/dashboard.rst
@@ -22,15 +22,17 @@ be found at https://dashboard.cloud.catalyst.net.nz.
 FAQ
 ***
 
-I cannot connect to the dashboard
-=================================
+I cannot connect to the dashboard or APIs
+=========================================
 
-Our dashboard and APIs are currently exposed to customers only (not open to the
+The dashboard is open to the public Internet, however various mechanisms are in
+place to protect the service.  If you are having difficulty accessing the
+dashboard, please contact us.
+
+Our APIs are currently exposed to customers only (not open to the
 public Internet). We ask for your IP address during sign up, so we can provide
-you with access to the dashboard and APIs.
-
-If your IP address has changed or you would like to add more IPs, please
-contact us to change the information provided.
+you with access to the APIs. If your IP address has changed or you would like
+to add more IPs, please contact us to change the information provided.
 
 Please note you can access the Catalyst Cloud from a dynamic IP by proxying
 your connectivity through one of your cloud instances. When it comes to your


### PR DESCRIPTION
Updates the Dashboard page to reflect the changes made to allow
relatively unfettered access to Horizon, the OpenStack dashboard.