### PR TITLE
Bugfix: Fix a very meta typo under Contribution

### DIFF
--- a/source/contributing.rst
+++ b/source/contributing.rst
@@ -220,9 +220,9 @@ As an example:
   .. _`Example website`: http://www.example.com/
 
 
-*****************
-Submiting a patch
-*****************
+******************
+Submitting a patch
+******************
 
 Go to https://github.com/catalyst/catalystcloud-docs and fork the docs to your
 own account on GitHub.


### PR DESCRIPTION
The section title "Submiting a patch" is short one 't'.
This commit fixes that.

signed-off-by: Martin Millnert <martin@millnert.se>