### PR TITLE
Improved section on Security Group Rules

### DIFF
--- a/source/first-instance.rst
+++ b/source/first-instance.rst
@@ -163,11 +163,13 @@ Navigate to the "Routers" section and click "Create Router":
 .. image:: _static/fi-router-create.png
    :align: center
 
+
 Name the router "border-router", select admin state "UP" and select
 "public-net" as the external network:
 
 .. image:: _static/fi-router-name.png
    :align: center
+
 
 Navigate to the "Networks" section and click "Create Network":
 
@@ -179,11 +181,13 @@ Name your network "private-net", select create subnet and click "Next":
 .. image:: _static/fi-network-create-name.png
    :align: center
 
+
 Name your subnet "private-subnet", choose an address for your subnet in CIDR
 notation and click "Next":
 
 .. image:: _static/fi-network-address.png
    :align: center
+
 
 Specify additional attributes for the subnet including enabling DHCP,
 specifying the `DNS Name Servers`_ for your region and optionally defining an
@@ -192,25 +196,30 @@ allocation pool:
 .. image:: _static/fi-network-detail.png
    :align: center
 
+
 Click on the router name in the router list:
 
 .. image:: _static/fi-router-detail.png
    :align: center
+
 
 Select the "Interfaces" tab and click "+Add Interface":
 
 .. image:: _static/fi-router-interface-add.png
    :align: center
 
+
 Select the correct subnet:
 
 .. image:: _static/fi-router-interface-subnet.png
    :align: center
 
+
 You should now have a network topology this looks like this:
 
 .. image:: _static/fi-network-topology.png
    :align: center
+
 
 Uploading an SSH key
 ====================
@@ -223,10 +232,12 @@ Select "Import Key Pair":
 .. image:: _static/fi-key-pair-import-1.png
    :align: center
 
+
 Enter your key pair name and paste your public key into the box:
 
 .. image:: _static/fi-key-pair-import-2.png
    :align: center
+
 
 Configure Instance Security Group
 =================================
@@ -239,20 +250,24 @@ click "Create Security Group":
 .. image:: _static/fi-security-group-create-1.png
    :align: center
 
+
 Enter a name and description and click "Create Security Group":
 
 .. image:: _static/fi-security-group-create-2.png
    :align: center
+
 
 Now click on "Manage Rules" for the group we have created:
 
 .. image:: _static/fi-security-group-rules-manage.png
    :align: center
 
+
 Click on “Add Rule”:
 
 .. image:: _static/fi-security-group-rule-add.png
    :align: center
+
 
 Enter 22 for the port number (this is the TCP port the SSH service listens on).
 You can use the default values for the remainder of the options. Click "Add":
@@ -260,17 +275,27 @@ You can use the default values for the remainder of the options. Click "Add":
 .. image:: _static/fi-security-group-rule-add-add.png
    :align: center
 
-|
+.. note::
+
+  If you intend to use your instance to host a website, repeat the steps
+  above, adding port 80 (HTTP) or port 443 (HTTP). Add both by making two
+  new rules, one for each port.
+  
+  Make sure to set CIDR 0.0.0.0/0 as a remote, allowing access
+  from any IP to your compute instance on the selected port. 
+
 
 .. warning::
 
-  Note that by using the CIDR 0.0.0.0/0 as a remote, you are allowing access
-  from any IP to your compute instance on the port and protocol selected. This
-  is often desirable when exposing a web server (eg: allow HTTP and HTTPs
-  access from the Internet), but is insecure when exposing other protocols,
-  such as SSH, Telnet and FTP. We strongly recommend you to limit the exposure
+  By using the CIDR 0.0.0.0/0 as a remote, you are allowing access
+  from any IP to your compute instance on the port and protocol selected. 
+  This is desirable when exposing a web server to the internet, but is 
+  insecure when exposing other protocols, such as SSH, Telnet and FTP. 
+  For those protocols, we strongly recommend you to limit the exposure
   of your compute instances and services to IP addresses or subnets that are
   trusted.
+
+
 
 Booting an Instance
 ===================
@@ -281,6 +306,7 @@ instances list:
 .. image:: _static/fi-instance-launch.png
    :align: center
 
+
 Enter an instance name, use the default instance count of one.  Select "Image"
 as the boot source and "No" for create new volume. Select the
 ``ubuntu-14.04-x86_64`` from the image list. Then click "Next":
@@ -288,20 +314,24 @@ as the boot source and "No" for create new volume. Select the
 .. image:: _static/fi-launch-instance-source.png
    :align: center
 
+
 Select the ``c1.c1r1`` flavor from the list and click "Next":
 
 .. image:: _static/fi-launch-instance-flavor.png
    :align: center
+
 
 Select the ``private-net`` network from the list and click "Next":
 
 .. image:: _static/fi-launch-instance-networks.png
    :align: center
 
+
 Select the ``first-instance-sg`` security group from the list and click "Next":
 
 .. image:: _static/fi-launch-instance-security-groups.png
    :align: center
+
 
 Select the ``first-instance-key`` key pair from the list and click "Next":
 
@@ -326,6 +356,7 @@ on "Associate":
 .. image:: _static/fi-floating-ip.png
    :align: center
 
+
 Select the port you wish to be associated with the floating IP. Ports are
 equivalent to virtual network interfaces of compute instances, and are named
 after the compute instance that owns it.
@@ -334,6 +365,7 @@ In this example, select the "first-instance" port and click "Associate":
 
 .. image:: _static/fi-floating-ip-associate.png
    :align: center
+
 
 Connect to the new Instance
 ===========================

--- a/source/ssh-filezilla-setup.rst
+++ b/source/ssh-filezilla-setup.rst
@@ -71,40 +71,44 @@ To check that SSH is installed, open a terminal and type:
   $ ssh -V
  
  
- You should get a response like this:
+You should get a response like this:
  
- .. code-block:: bash
+.. code-block:: bash
   
   OpenSSH_7.2p2 Ubuntu-4ubuntu1, OpenSSL 1.0.2g-fips  1 Mar 2016
  
  
- To check that SSH is running, type:
+To check that SSH is running, type:
  
 .. code-block:: bash
   
   $ ps aux | grep sshd
  
  
- You should get a response like this:
- 
- (user)   5404  0.0  0.0  21300   984 pts/2    S+   13:13   0:00 grep --color=auto sshd
- 
- 
- Install and start SSH
- =====================
- 
- If one or other of these does not return the expected result, then install
- OpenSSH with the command:
+You should get a response like this:
  
 .. code-block:: bash
  
-  sudo apt-get install openssh-client
+  (user)   5404  0.0  0.0  21300   984 pts/2    S+   13:13   0:00 grep --color=auto sshd
+ 
+ 
+ 
+Install and start SSH
+=====================
+ 
+If one or other of these does not return the expected result, then install
+OpenSSH with the command:
+ 
+.. code-block:: bash
+ 
+  $ sudo apt-get install openssh-client
+  
 
 Now restart your computer, or start OpenSSH with the command:
  
- .. code-block:: bash
+.. code-block:: bash
  
-  sudo ssh start
+  $ sudo ssh start
 
 
 Finally run the checks above, to make sure it's working.

--- a/source/ssh-filezilla-setup.rst
+++ b/source/ssh-filezilla-setup.rst
@@ -51,14 +51,14 @@ Key-based authentication is working properly.
 
 Generating a key pair provides you with two long string of characters: 
 a “public key” and a “private key”. Anyone is allowed to see the public key, 
-but only the owner is allowed to see the private key.
-You can place the public key on any server, and then unlock it by connecting 
-to it with a client that already has the private key. When the two match up, 
-the system unlocks without the need for a password. 
-You can increase security even more by protecting the private key with a passphrase.
+but only the owner is allowed to see the private key. You place the public key 
+on a server, and then unlock it by connecting to it with a client that already 
+has the private key. If the two match up, the system unlocks without the need for 
+a password. You can increase security even more by protecting the private key 
+with a passphrase.
+
 SSH can use either "RSA" (Rivest-Shamir-Adleman) or "DSA" ("Digital Signature Algorithm") keys. 
-DSA is known to be less secure, so RSA is recommended: this guide uses "RSA key" 
-and "SSH key" interchangeably.
+DSA is known to be less secure, so RSA is used in this guide.
 
 ******************************************
 Step 1: Check that SSH is installed and running 
@@ -69,11 +69,13 @@ To check that SSH is installed, open a terminal and type:
 
  $ ssh -V
  
+ 
  You should get a response like this:
  
  .. code-block:: bash
 
  OpenSSH_7.2p2 Ubuntu-4ubuntu1, OpenSSL 1.0.2g-fips  1 Mar 2016
+ 
  
  To check that SSH is running, type:
  
@@ -81,9 +83,11 @@ To check that SSH is installed, open a terminal and type:
 
  $ ps aux | grep sshd
  
+ 
  You should get a response like this:
  
  (user)   5404  0.0  0.0  21300   984 pts/2    S+   13:13   0:00 grep --color=auto sshd
+ 
  
  Install and start SSH
  =====================
@@ -95,11 +99,70 @@ To check that SSH is installed, open a terminal and type:
    
    sudo apt-get install openssh-client
    
- And then restart your computer or start OpenSSH with the command:
+
+And then restart your computer or start OpenSSH with the command:
  
    .. code-block:: bash
    
    sudo ssh start
    
+
 And then run the checks above, to make sure it's working.
  
+
+******************************************
+ Step 2: Create an RSA Key Pair
+ ******************************************
+ 
+Create the key pair on the client machine (your computer). 
+Open a terminal and go to your SSH folder by typing:
+
+.. code-block:: bash
+$ cd /home/(your_username)/.ssh/
+
+Change the read/write permissions of the folder:
+
+.. code-block:: bash
+$ sudo chmod 700 ~/.ssh
+
+Check to see of any Key Pair files already exist: 
+
+.. code-block:: bash
+$ ls -l
+
+If the files id_rsa and id_rsa.pub already exist, and you’re not sure 
+what they are for, you should probably make copies or backups before proceeding:
+
+.. code-block:: bash
+$ cp id_rsa.pub id_rsa.pub.bak
+$ cp id_rsa id_rsa.bak
+
+Now generate the new RSA Key Pair, using the default name:
+
+.. code-block:: bash
+$ ssh-keygen -t rsa
+
+Option: Create unique key file names
+=====================================
+
+You will want to add a new and unique key file name if you are making more 
+than one set of keys, to access different projects or instances. 
+It is probably wiser to do this if the files id_rsa and id_rsa.pub already exist. 
+
+Create a unique name using the -f flag:
+
+$ ssh-keygen -t rsa -f newKeyName
+
+Option: Set Key Encryption Level
+====================================
+The default key is 2048 bits. You can increase this to 4096 bits with the -b flag, making it harder to crack the key by brute force methods.
+$ ssh-keygen -t rsa -b 4096
+Add your SSH key to the ssh-agent
+Ensure ssh-agent is enabled by starting the ssh-agent in the background:
+$ eval "$(ssh-agent -s)"
+Agent pid 59566
+Now Add your new SSH key to the ssh-agent. 
+$ ssh-add ~/.ssh/id_rsa
+
+
+If you used an existing SSH key rather than generating a new SSH key, you'll need to replace id_rsa in the command with the name of your existing private key file.

--- a/source/ssh-filezilla-setup.rst
+++ b/source/ssh-filezilla-setup.rst
@@ -123,7 +123,7 @@ Open a terminal and go to your SSH folder by typing:
 
 .. code-block:: bash
 
-$ cd /home/(your_username)/.ssh/
+  $ cd /home/(your_username)/.ssh/
 
 Change the read/write permissions of the folder:
 

--- a/source/ssh-filezilla-setup.rst
+++ b/source/ssh-filezilla-setup.rst
@@ -348,15 +348,15 @@ from your text editor into the box.
 Transfer Client Key to Host with command line (if you must)
 ===============================================================
 
-If you can log in to a computer over SSH using a password, you can 
-transfer your RSA key to the server by using the terminal command:
+If you really want to stay on the command line, and if you can log in to the server 
+using a password, you can transfer your RSA key to the server by using terminal commands.
+There are three different ways of doing this.
+
+**First method:**
 
 .. code-block:: bash
 
-  $ ssh-copy-id <username>@<host>
-
-Where <username> and <host> should be replaced by your username 
-and the name of the computer you're transferring your key to.
+  $ ssh-copy-id ubuntu@<Public_IP>
 
 The method above uses the default port 22. If you are not using port 22, 
 then issue the command with a -p flag and the port number: 
@@ -365,30 +365,29 @@ then issue the command with a -p flag and the port number:
 
   $ ssh-copy-id "<username>@<host> -p <port_number>"
 
-Another method is to copy the public key file to the server and 
-concatenate it onto the authorized_keys file manually. 
+**Second method:**
 
-First, make a backup of the authorised_keys file, then concatenate the Public Key:
+Copy the public key file to the remote server and 
+concatenate it onto the authorized_keys file manually. These two commands 
+(1) make a backup of the authorised_keys file, then (2) concatenate 
+the Public Key into the original file:
 
 .. code-block:: bash
 
   $ cp authorized_keys authorized_keys_Backup
   $ cat myNewKey.pub >> authorized_keys
 
-You can copy the public key into the new machine's authorized_keys file 
-with the ssh-copy-id command. Make sure to replace the example username and IP address below.
+**Third method:**
 
-.. code-block:: bash
-
-  $ ssh-copy-id ubuntu@<public_IP>
-
-Alternatively, you can paste in the keys using SSH:
+Paste in the keys using SSH:
 
 .. code-block:: bash
 
   $ cat ~/.ssh/myNewKey.pub | ssh ubuntu@<public_IP> "mkdir -p ~/.ssh && cat >>  ~/.ssh/authorized_keys" ]
 
-No matter which command you chose, you should then see something like:
+**Result:**
+
+No matter which method you chose, you should then see something like:
 
 .. code-block:: bash
 
@@ -398,7 +397,7 @@ No matter which command you chose, you should then see something like:
   Warning: Permanently added '<public_IP>' (RSA) to the list of known hosts.
   ubuntu@public_IP's password: 
 
-Type in your password and continue.
+Type in your password (NOT your *passphrase*) and continue.
 
 
 ******************************************

--- a/source/ssh-filezilla-setup.rst
+++ b/source/ssh-filezilla-setup.rst
@@ -33,10 +33,10 @@ The steps required to establish an encrypted SSH connection are:
 
 Before we get going, there is a subsection which explains
 why we use RSA key pairs to make secure connections over 
-the internet.
+the internet. 
 
-The last section is a Trouble-shooting guide, if things
-don't work exacctly as expected.
+The final section is a Trouble-shooting guide, if things
+don't work exactly as expected.
 
 **************
 About SSH Keys
@@ -63,25 +63,26 @@ DSA is known to be less secure, so RSA is used in this guide.
 ******************************************
 Step 1: Check that SSH is installed and running 
 ******************************************
+
 To check that SSH is installed, open a terminal and type:
 
 .. code-block:: bash
-
- $ ssh -V
+  
+  $ ssh -V
  
  
  You should get a response like this:
  
  .. code-block:: bash
-
- OpenSSH_7.2p2 Ubuntu-4ubuntu1, OpenSSL 1.0.2g-fips  1 Mar 2016
+  
+  OpenSSH_7.2p2 Ubuntu-4ubuntu1, OpenSSL 1.0.2g-fips  1 Mar 2016
  
  
  To check that SSH is running, type:
  
-  .. code-block:: bash
-
- $ ps aux | grep sshd
+.. code-block:: bash
+  
+  $ ps aux | grep sshd
  
  
  You should get a response like this:
@@ -95,19 +96,18 @@ To check that SSH is installed, open a terminal and type:
  If one or other of these does not return the expected result, then install
  OpenSSH with the command:
  
-   .. code-block:: bash
-   
-   sudo apt-get install openssh-client
-   
-
-And then restart your computer or start OpenSSH with the command:
+.. code-block:: bash
  
-   .. code-block:: bash
-   
-   sudo ssh start
-   
+  sudo apt-get install openssh-client
 
-And then run the checks above, to make sure it's working.
+Now restart your computer, or start OpenSSH with the command:
+ 
+ .. code-block:: bash
+ 
+  sudo ssh start
+
+
+Finally run the checks above, to make sure it's working.
  
 
 ******************************************
@@ -118,28 +118,33 @@ Create the key pair on the client machine (your computer).
 Open a terminal and go to your SSH folder by typing:
 
 .. code-block:: bash
+
 $ cd /home/(your_username)/.ssh/
 
 Change the read/write permissions of the folder:
 
 .. code-block:: bash
+
 $ sudo chmod 700 ~/.ssh
 
 Check to see of any Key Pair files already exist: 
 
 .. code-block:: bash
+
 $ ls -l
 
 If the files id_rsa and id_rsa.pub already exist, and you’re not sure 
 what they are for, you should probably make copies or backups before proceeding:
 
 .. code-block:: bash
+
 $ cp id_rsa.pub id_rsa.pub.bak
 $ cp id_rsa id_rsa.bak
 
 Now generate the new RSA Key Pair, using the default name:
 
 .. code-block:: bash
+
 $ ssh-keygen -t rsa
 
 Option: Create unique key file names
@@ -155,6 +160,7 @@ Create a unique name using the -f flag:
 
 $ ssh-keygen -t rsa -f newKeyName
 
+
 Option: Set Key Encryption Level
 ====================================
 
@@ -162,6 +168,7 @@ The default key is 2048 bits. You can increase this to 4096 bits with the -b fla
 making it harder to crack the key by brute force methods.
 
 .. code-block:: bash
+
 $ ssh-keygen -t rsa -b 4096
 
 Add your SSH key to the ssh-agent
@@ -169,12 +176,14 @@ Add your SSH key to the ssh-agent
 Ensure ssh-agent is enabled by starting the ssh-agent in the background:
 
 .. code-block:: bash
+
 $ eval "$(ssh-agent -s)"
 Agent pid 59566
 
 Now Add your new SSH key to the ssh-agent.
 
 .. code-block:: bash
+
 $ ssh-add ~/.ssh/id_rsa
 
 If you used an existing SSH key rather than generating a new SSH key, 

--- a/source/ssh-filezilla-setup.rst
+++ b/source/ssh-filezilla-setup.rst
@@ -17,25 +17,27 @@ After you have completed the steps you will be able to log
 on to the server via SSH from your local machine, with an strongly
 encrypted connection.
 
-This section assumes You have a Catalyst Cloud account, and you're 
-preparing to create your first instance. It is verbose: written for 
-a relative newbie, who has not set up an SSH connection to a remote 
-server before, but has some experience with the command line interface (terminal).
+This section assumes you have a Catalyst Cloud account, and you're 
+preparing to create your first instance. It is written for a relative newbie, 
+who has not set up an SSH connection to a remote server before, but has some
+experience with the command line interface (terminal). The commands are 
+written for, and tested, on a machine running Ubuntu 16.04.
 
 The steps required to establish an encrypted SSH connection are:
 
-1. Check that you have OpenSSH
+1. Check that OpenSSH is installed and running
 2. Create an RSA Key Pair
 3. Finish off by securing your key
 4. Upload the Public Key to a cloud server
 5. Connect to the cloud server
-6. Set-up FileZilla with your SSH key
+6. Set-up FileZilla with your SSH key (optional)
+7. Disable password authentication (optional)
 
 Before we start, there is a subsection which explains
 why we use RSA key pairs to make secure connections over 
 the internet. 
 
-The final section is a Trouble-shooting guide, if things
+The final section is a trouble shooting guide, if things
 don't work exactly as expected.
 
 **************
@@ -48,14 +50,15 @@ secure method, and is therefore recommended.
 
 Other authentication methods are only used in specific situations (such as 
 setting a password log-in when creating a new instance). Ideally, password 
-authentication should be disabled, once SSH your key-based authentication 
+authentication should be disabled once SSH your key-based authentication 
 is set up and working properly.
 
 Generating a key pair provides you with two long string of characters: 
 a “public key” and a “private key”. Anyone is allowed to see the public key, 
 but only the owner is allowed to see the private key. You place the public key 
 on a server, and then unlock it by connecting to it with a client that already 
-has the private key. If the two match up, the system unlocks without the need for 
+has the private key. If the two keys match up, the server and client are 
+connected, with a strongly encrypted connection, without the need for 
 a password. You can increase security even more by protecting the private key 
 with a passphrase.
 
@@ -114,7 +117,7 @@ Now restart your computer, or start OpenSSH with the command:
   $ sudo ssh start
 
 
-Now run the checks above, again, to make sure it's working.
+Run the checks again, to make sure it's working.
  
 
 ******************************************
@@ -135,7 +138,7 @@ these back again in Step 3):
 
   $ sudo chmod 700 ~/.ssh
 
-You don't want to overwrite an existing key pai, check to see of any 
+You don't want to overwrite an existing Key Pair, check to see if any 
 Key Pair files already exist, and what their names are:
 
 
@@ -164,14 +167,14 @@ OR generate a new Key Pair with a unique name using the -f flag:
 
   $ ssh-keygen -t rsa -f newKeyName
 
-You will want to add a new and unique key file name if you are making more 
+You will want a unique key file name if you will be making more 
 than one set of keys, to access different projects or instances. 
 
-.. note::
-
-  **Set Key Encryption Level**
-  The default key is 2048 bits. You can increase this to 4096 bits with the -b flag, 
-  making it harder to crack the key by brute force methods.
+Optional: Increase Key Encryption Level
+=======================================
+  
+The default key is 2048 bits. You can increase this to 4096 bits with the -b flag,
+making it harder to crack the key by brute force methods.
 
 .. code-block:: bash
 
@@ -180,16 +183,16 @@ than one set of keys, to access different projects or instances.
 
 Once you have entered the keygen command, you will get this response (with your username in it):
 
-.. code-block:: BASH
+.. code-block:: bash
 
   Enter file in which to save the key (/home/(username)/.ssh/id_rsa):
 
-This provides a default file path and filename, where SSH will automatically 
-look for your private key when you are using it to log in. You can press enter 
-here, saving the file to the default folder. 
+You can press enter here, saving the file to the default folder where SSH will automatically 
+look for your private key when you are using it to log in.  
 
 If you specify another folder, you will need to enter its file path when you 
-issue a log-in command (explained below).
+issue a log in command (explained below).  You may want to use different folders
+to store the Key Pair files for different projects or instances.
 
 SSH will now ask for a passphrase:
 
@@ -215,7 +218,7 @@ a new key must be generated and the corresponding public key copied to other mac
 
 If you use a passphrase, pick a strong one and store it securely in a password manager, 
 or write it down on a piece of paper and keep it in a secure place. Obviously, you should 
-not store it on the client machine that you are using to connect to your server!
+not store it on the client machine that you are using to connect to your server.
 
 
 Key Pair Generated successfully
@@ -247,8 +250,8 @@ The entire key generation process will look something like this in your terminal
   |                 |
   +-----------------+
 
-It is a good idea to select all of this information, use ctrl + shift + c to copy it
-from the terminal, and paste it into a text editor file.  Add the passphrase, if you used
+It is a good idea to select all of this information, use ``ctrl`` + ``shift`` + ``c`` to copy it
+from the terminal, and paste it into a text editor file.  Then add the passphrase, if you used
 one. Then save the text file and store it somewhere very safe.
 
 ******************************************
@@ -288,10 +291,11 @@ users won't have access to it
   $ chmod 600 myNewKey
 
 
-.. note:: 
+.. warning:: 
 
   If you fail to do this, you may get an error when you try to use the
   key: ``Permissions... are too open. This private key will be ignored''
+  
   
 Repeat Steps 2 to 3 for each Instance
 =====================================
@@ -299,8 +303,8 @@ Repeat Steps 2 to 3 for each Instance
 On OpenStack (and the Catalyst Cloud), each instance can have only one Key Pair,
 and one public IP address. 
 
-You will need to repeat steps 2 to 3 for each instance that you wish to access
-with SSH. And this is where it becomes important to think about using unique Key Pair
+That means will need to repeat steps 2 to 3 for each instance that you wish to access
+with SSH. This is where it becomes important to think about using unique Key Pair
 file names, which reflect the name of the instance they will be attached to.
 
 There are some other implications:
@@ -311,15 +315,15 @@ There are some other implications:
 
 * If you install a Key Pair on only one machine, which it is subsequently lost, stolen or destroyed, then you may have a significant problem.  
 
-It is advisable to make a copy of your private and public Key Pair files and store them 
-somewhere safe (e.g. on an encrypted USB drive). **This might be a good moment to do that.**
+It is advisable to make copies of your private and public Key Pair files and store them 
+somewhere safe (e.g. on an encrypted USB drive). *This might be a good moment to do that.*
 
 
 ******************************************
 Step 4: Upload the Public Key to Cloud Server
 ******************************************
 
-Now it's time to place the public key on the virtual server we want to use. 
+Now it's time to place the public key on the virtual server. 
 You will need to open the public key file, to copy and upload it. 
 Assuming you use gedit as a text editor, open a terminal and type:
 
@@ -335,7 +339,7 @@ Enter a key pair name, then copy and paste your public key
 from your text editor into the box. 
 
 
-Transfer Client Key to Host with command line (not recommended)
+Transfer Client Key to Host with command line (if you must)
 ===============================================================
 
 If you can log in to a computer over SSH using a password, you can 
@@ -356,19 +360,21 @@ then issue the command with a -p flag and the port number:
   $ ssh-copy-id "<username>@<host> -p <port_number>"
 
 Another method is to copy the public key file to the server and 
-concatenate it onto the authorized_keys file manually. It is wise to back that up first:
+concatenate it onto the authorized_keys file manually. 
+
+First, make a backup of the authorised_keys file, then concatenate the Public Key:
 
 .. code-block:: bash
 
   $ cp authorized_keys authorized_keys_Backup
-  $ cat id_rsa.pub >> authorized_keys
+  $ cat myNewKey.pub >> authorized_keys
 
 You can copy the public key into the new machine's authorized_keys file 
 with the ssh-copy-id command. Make sure to replace the example username and IP address below.
 
 .. code-block:: bash
 
-  $ ssh-copy-id user@123.45.56.78 ]
+  $ ssh-copy-id ubuntu@<public_IP>
 
 Alternatively, you can paste in the keys using SSH:
 
@@ -376,7 +382,7 @@ Alternatively, you can paste in the keys using SSH:
 
   $ cat ~/.ssh/myNewKey.pub | ssh ubuntu@<public_IP> "mkdir -p ~/.ssh && cat >>  ~/.ssh/authorized_keys" ]
 
-No matter which command you chose, you should see something like:
+No matter which command you chose, you should then see something like:
 
 .. code-block:: bash
 
@@ -394,12 +400,12 @@ Step 5: Connecting to the new Instance
 ******************************************
 
 You can now connect to the SSH service using the floating public IP that you 
-associated with your instance in the previous step. This IP address address is 
-visible in the Instances list or under the Floating IPs tab in Access & Security.
+associated with your instance in the previous step. On your Catalyst Cloud Dashboard the
+IP address address is visible in the Instances list or under the Floating IPs tab in Access & Security.
 
 .. code-block:: bash
 
-  $ ssh -i ~/<myKeyName> ubuntu@<FLOATING_IP>
+  $ ssh -i ~/<myKeyName> ubuntu@<public_IP>
 
 If you have set a passphrase, you will be asked to enter the passphrase now.
 
@@ -411,14 +417,18 @@ If you have set a passphrase, you will be asked to enter the passphrase now.
  terminal window. 
  Just enter you passphrase into the dialog box and continue.
  
-You should be able to interact with this instance as you would any Ubuntu server.
+Success
+=======
+
+You should be able to interact with your new instance as you would any Ubuntu server.
 
 And from now on, you only need to enter this command in the terminal to access the
 instance:
 
 .. code-block:: bash
 
-  $ ssh ubuntu@<FLOATING_IP>
+  $ ssh ubuntu@<Public_IP>
+
 
 ******************************************
 Step 6: Use FileZilla with an SSH key (optional)
@@ -428,11 +438,10 @@ Filezilla gives you a GUI overview of your Instance’s filesystem, with the abi
 to quickly and easily upload or download files from your local machine to the 
 cloud server using SFTP (SSH File Transfer Protocol). 
 
-You can access the server with Filezilla by using the password with SFTP, if you want. 
-But using the key pair encryption is much safer. 
-
-If you want to disable password login for security reasons (see below), you’ll need 
-to set up Filezilla to utilise the private key you have now created.
+You can access the server with Filezilla by using the password, if you want, 
+but using your Key Pair encryption is much safer. And if you want to disable 
+password login for security reasons (see below), you’ll need to set up 
+Filezilla to utilise the private key you have now created.
 
 Open the menu ``Edit`` > ``Preferences…`` then navigate to ``Connection`` > ``SFTP``.
 
@@ -441,11 +450,11 @@ Open the menu ``Edit`` > ``Preferences…`` then navigate to ``Connection`` > ``
 Add your private key file by clicking the ``Add keyfile…`` button, choosing
 ``all file types`` and navigating to your new private key file (e.g. /home/(user)/.myNewKey).  
 
-Note: you may have to select View > Show Hidden Files to get to the .ssh/ folder: 
+Note: you may have to select ``View`` > ``Show Hidden Files`` to get to the **.ssh/** folder: 
 
 When you select the private key file, Filezilla will ask if you want to convert it to a PPK file. 
 Say yes, add a new filename,  and save it in the same folder.  To avoid confusion, 
-the new filename should be something like myNewKey_fz.ppk (make sure to add the .ppk suffix).
+the new filename should be something like ``myNewKey_fz.ppk`` (make sure to add the .ppk suffix).
 
 Now go to ``File`` > ``Site Manager…`` and add a ``New Site``.
 
@@ -468,35 +477,26 @@ Enter the details as required:
 Then click ``OK``
 
 Now you can access your cloud server’s file system by opening Filezilla 
-and clicking, or right-clicking on the server symbol at the top left corner 
+and clicking, or right-clicking, on the server symbol at the top left corner 
 of the Filezilla window, then selecting the site you just created. 
 
 ******************************************
 Step 7: Disable Password Authentication (optional)
 ******************************************
 
-If you have followed the steps above, you should always be able to log in 
-to your server with an SSH key. You should should consider disabling
-password authentication altogether.
+If you have followed the steps above, including saving a copy of your 
+Key Pair in a secure place, you should always be able to log in to your 
+server with an SSH key. 
 
-Key pair authentication massively improves your security, but makes it impossible 
-for you to connect to your server from a friendly PC without first installing your
-key pair on it.
-
+You should should now consider disabling password authentication altogether.
 It is recommended to disable password authentication unless you have a 
 specific reason not to.
 
 To disable password authentication
 ==================================
 
-Once you have copied your SSH keys unto your server and ensured that you can 
-log in with the SSH keys alone, you can go ahead and restrict the root login 
-to only be permitted via SSH keys.
-
-In order to do this, log in to your instance.
-
-First, make a backup of your ``sshd_config`` file by copying it to your home directory, 
-or by making a read-only copy in ``/etc/ssh`` by doing:
+Log in to your instance and make a backup of your ``sshd_config`` file 
+by copying it to your home directory, or by making a read-only copy in ``/etc/ssh`` by doing:
 
 .. code-block:: bash
 
@@ -513,30 +513,30 @@ Find the line that includes **PermitRootLogin** and modify it to ensure that use
 
 .. code-block:: bash
   
-  **PermitRootLogin without-password**
+  PermitRootLogin without-password
 
 Also look for the line:
 
 .. code-block:: bash
 
-  **#PasswordAuthentication yes**
+  #PasswordAuthentication yes
   
-Replace it with:
+Uncomment it (delete the #), and change ``yes`` to ``no``:
 
 .. code-block:: bash
 
-  **PasswordAuthentication no**
+  PasswordAuthentication no
   
-Once you've made your changes you can save the file with ``ctrl`` + ``X``
+Once you've made your changes you can save the file with ``ctrl`` + ``X``,
 then entering ``Y`` to save changes.
 
-Now apply the changes by doing:
+Now apply the changes with the command:
 
 .. code-block:: bash
 
   $ reload ssh
 
-Now you should never be asked for a password when you log in.
+Now you should only be able to log in using a secure SSH connection.
 
 *****************
 Troubleshooting
@@ -559,9 +559,11 @@ You can change the passphrase for an existing private key without regenerating t
 Just type the following command:
 
 .. code-block:: bash
+
  $ ssh-keygen -p
 
 .. code-block:: bash
+
  # Start the SSH key creation process
  Enter file in which the key is (/Users/you/.ssh/id_rsa): [Hit enter]
  Key has comment '/Users/you/.ssh/id_rsa'
@@ -583,45 +585,98 @@ To solve this, create a folder outside your home named /etc/ssh/<username>
 and be owned by the user. Move the authorized_keys file into it. The authorized_keys file 
 should have 644 permissions and be owned by the user.
 
-Then edit your /etc/ssh/sshd_config and add:
-AuthorizedKeysFile    /etc/ssh/%u/authorized_keys
+Then edit your ``/etc/ssh/sshd_config`` file with nano bby adding:
+
+.. code-block:: bash
+
+  AuthorizedKeysFile    /etc/ssh/%u/authorized_keys
+
 Finally, restart ssh with:
-sudo service ssh restart
+
+.. code-block:: bash
+
+  $ sudo service ssh restart
+  
 The next time you connect with SSH you should not have to enter your password.
-username@host's password:
+
+Password requested (not passphrase)
+=========================
+
 If you are not prompted for the passphrase, and instead get:
-username@host's password:
-On the host computer, ensure that the file: /etc/ssh/sshd_config contains the following lines, and that they are uncommented;
-PubkeyAuthentication yes
-RSAAuthentication yes
-If not, add them, or uncomment them, restart OpenSSH, and try logging in again. If you get the passphrase prompt now, then congratulations, you're logging in with a key!
+
+.. code-block:: bash
+
+  $ ubuntu@<Public_IP> password:
+  
+Log in to the server and ensure that the file: ``/etc/ssh/sshd_config`` contains 
+the following lines, and that they are uncommented:
+
+.. code-block:: bash
+
+  PubkeyAuthentication yes
+  RSAAuthentication yes
+  
+If not; add them, or uncomment them. Then restart OpenSSH, and try logging in again. 
+If you get the passphrase prompt now, then you're logging in with a key.
+
 Permission denied (publickey)
-If you're sure you've correctly configured sshd_config, copied your ID, and have your private key in the .ssh directory, and still getting this error:
-Permission denied (publickey).
-Chances are the permissions for your /home/<user> (folder) or ~/.ssh/authorized_keys (file) are too accessible, by OpenSSH standards. You can get rid of this problem by issuing the following chmod commands:
-chmod go-w ~/     (explain)
-chmod 700 ~/.ssh
-chmod 600 ~/.ssh/authorized_keys
-Error: Agent admitted failure to sign using the key.
-This error occurs when the ssh-agent on the client is not yet managing the key. Issue the following commands to fix: 
-ssh-add
+=============================
+
+If you're sure you've correctly configured sshd_config, copied your ID, 
+and have your private key in the .ssh directory, and still getting this error:
+
+.. code-block:: bash
+
+  Permission denied (publickey).
+  
+Chances are the permissions for your /home/<user> (folder) or ~/.ssh/authorized_keys 
+(file) are too accessible, by OpenSSH standards. You can get rid of this problem 
+by issuing the following chmod commands:
+
+.. code-block:: bash
+
+  chmod go-w ~/     (explain)
+  chmod 700 ~/.ssh
+  chmod 600 ~/.ssh/authorized_keys
+  
+  
+Error: Agent admitted failure to sign using the key
+===================================================
+
+This error occurs when the ssh-agent on the client is not managing the key. 
+Issue the following commands to fix: 
+
+.. code-block:: bash
+  $ ssh-add
+
 This command should be entered after you have copied your public key to the host computer.
+
 
 Remote Host Identification Has Changed
 ======================================
-@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-@    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @
-@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!
-Someone could be eavesdropping on you right now (man-in-the-middle attack)!
-It is also possible that a host key has just been changed.
-The fingerprint for the ECDSA key sent by the remote host is
-SHA256:aGZ5Fs+qEf4ESngJdksqAcn+L4H7WeOwY8nu0HsR7c4.
-Please contact your system administrator.
-Add correct host key in /home/(user)/.ssh/known_hosts to get rid of this message.
-Offending ECDSA key in /home/(user)/.ssh/known_hosts:2
-  remove with:
-  ssh-keygen -f "/home/(user)/.ssh/known_hosts" -R <IP_ADDRESS>
-ECDSA host key for <IP_ADDRESS> has changed and you have requested strict checking.
-Host key verification failed.
 
+You get this scary message.
+
+.. code-block:: bash
+
+  @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+  @    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @
+  @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+  IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!
+  Someone could be eavesdropping on you right now (man-in-the-middle attack)!
+  It is also possible that a host key has just been changed.
+  The fingerprint for the ECDSA key sent by the remote host is
+  SHA256:aGZ5Fs+qEf4ESngJdksqAcn+L4H7WeOwY8nu0HsR7c4.
+  Please contact your system administrator.
+  Add correct host key in /home/(user)/.ssh/known_hosts to get rid of this message.
+  Offending ECDSA key in /home/(user)/.ssh/known_hosts:2
+  remove with:
+  ssh-keygen -f "/home/(user)/.ssh/known_hosts" -R <Public_IP>
+  ECDSA host key for <Public_IP> has changed and you have requested strict checking.
+  Host key verification failed.
+
+Just do what it says in that third-to-last line. In your local terminal type:
+
+.. code-block:: bash
+
+  $ ssh-keygen -f "/home/(user)/.ssh/known_hosts" -R <Public_IP>

--- a/source/ssh-filezilla-setup.rst
+++ b/source/ssh-filezilla-setup.rst
@@ -11,19 +11,16 @@ Overview
 
 This section provides step-by-step advice on setting up a connection
 to your Catalyst Cloud instance from your local (client) machine.
-
-Some of the steps are required before you create a new instance
+Steps 1 through 3 are required before you create a new instance.
 
 After you have completed the steps you will be able to log
 on to the server via SSH from your local machine, with an strongly
 encrypted connection.
 
 This section assumes You have a Catalyst Cloud account, and you're 
-preparing to create your first instance.
-
-This guide is verbose: it's written for a relative "newbie", who has not set 
-up an SSH connection to a remote server before, but has some experience with
-the command line interface (terminal).
+preparing to create your first instance. It is verbose: written for 
+a relative newbie, who has not set up an SSH connection to a remote 
+server before, but has some experience with the command line interface (terminal).
 
 The steps required to establish an encrypted SSH connection are:
 
@@ -63,5 +60,46 @@ SSH can use either "RSA" (Rivest-Shamir-Adleman) or "DSA" ("Digital Signature Al
 DSA is known to be less secure, so RSA is recommended: this guide uses "RSA key" 
 and "SSH key" interchangeably.
 
+******************************************
+Step 1: Check that SSH is installed and running 
+******************************************
+To check that SSH is installed, open a terminal and type:
 
+.. code-block:: bash
 
+ $ ssh -V
+ 
+ You should get a response like this:
+ 
+ .. code-block:: bash
+
+ OpenSSH_7.2p2 Ubuntu-4ubuntu1, OpenSSL 1.0.2g-fips  1 Mar 2016
+ 
+ To check that SSH is running, type:
+ 
+  .. code-block:: bash
+
+ $ ps aux | grep sshd
+ 
+ You should get a response like this:
+ 
+ (user)   5404  0.0  0.0  21300   984 pts/2    S+   13:13   0:00 grep --color=auto sshd
+ 
+ Install and start SSH
+ =====================
+ 
+ If one or other of these does not return the expected result, then install
+ OpenSSH with the command:
+ 
+   .. code-block:: bash
+   
+   sudo apt-get install openssh-client
+   
+ And then restart your computer or start OpenSSH with the command:
+ 
+   .. code-block:: bash
+   
+   sudo ssh start
+   
+And then run the checks above, to make sure it's working.
+ 

--- a/source/ssh-filezilla-setup.rst
+++ b/source/ssh-filezilla-setup.rst
@@ -304,8 +304,11 @@ with SSH. And this is where it becomes important to think about using unique Key
 file names, which reflect the name of the instance they will be attached to.
 
 There are some other implications:
+
 * If you want to access one instance from multiple machines, you need to install the same Key Pair on each machine. 
-* If you want multiple users to access one instance, then each user must to install the same Key Pair on their machine.  
+
+* If you want multiple users to access one instance, then each user must to install the same Key Pair on their machine. 
+
 * If you install a Key Pair on only one machine, which it is subsequently lost, stolen or destroyed, then you may have a significant problem.  
 
 It is advisable to make a copy of your private and public Key Pair files and store them 

--- a/source/ssh-filezilla-setup.rst
+++ b/source/ssh-filezilla-setup.rst
@@ -419,4 +419,54 @@ instance:
 
   $ ssh ubuntu@<FLOATING_IP>
 
+******************************************
+Step 6: Use FileZilla with an SSH key 
+******************************************
+
+Filezilla gives you a GUI overview of your Instance’s filesystem, with the ability 
+to quickly and easily upload or download files from your local machine to the 
+cloud server using SFTP (SSH File Transfer Protocol). 
+
+You can access the server with Filezilla by using the password with SFTP, if you want. 
+But using the key pair encryption is much safer. 
+
+If you want to disable password login for security reasons (see below), you’ll need 
+to set up Filezilla to utilise the private key you have now created.
+
+Open the menu ``Edit`` > ``Preferences…`` then navigate to ``Connection`` > ``SFTP``.
+
+[insert image]
+
+Add your private key file by clicking the ``Add keyfile…`` button, choosing
+``all file types`` and navigating to your new private key file (e.g. /home/(user)/.myNewKey).  
+
+Note: you may have to select View > Show Hidden Files to get to the .ssh/ folder: 
+
+When you select the private key file, Filezilla will ask if you want to convert it to a PPK file. 
+Say yes, add a new filename,  and save it in the same folder.  To avoid confusion, 
+the new filename should be something like myNewKey_fz.ppk (make sure to add the .ppk suffix).
+
+Now go to ``File`` > ``Site Manager…`` and add a ``New Site``.
+
+Enter the details as required:
+
+  **Host:** the floating Public IP address attached to your instance
+
+  **Port:** 22 (if using the default port)
+
+  **Protocol:** SFTP - SSH File Transfer Protocol
+
+  **Logon Type:** Key file
+
+  **User:** ubuntu (or your chosen distribution name) 
+
+  **Key File:** browse to the .ppk file you just created
+  
+[ Insert Image ]
+
+Then click ``OK``
+
+Now you can access your cloud server’s file system by opening Filezilla 
+and clicking, or right-clicking on the server symbol at the top left corner 
+of the Filezilla window, then selecting the site you just created. 
 

--- a/source/ssh-filezilla-setup.rst
+++ b/source/ssh-filezilla-setup.rst
@@ -1,0 +1,46 @@
+.. _setting-up-local-connections:
+
+################################################
+Setting up SSH and Filezilla connections locally
+################################################
+
+
+********
+Overview
+********
+
+This section provides step-by-step advice on setting up a connection
+to your Catalyst Cloud instance from your local (client) machine.
+After you have completed the steps you will be able to log
+on to the server via SSH from anywhere on the internet using an SSH key.
+
+This section assumes you are a relative "newbie", who may not have set 
+up an SSH connection to a remote server before. You have a Catalyst Cloud 
+account, and you're preparing to create your first instance.  You know
+how to use the command line interface (terminal), but may not be very
+experienced with it.
+
+The steps required to establish an encrypted SSH connection are:
+
+1. Install an configure OpenSSH
+2. Create a Router
+3. Upload an SSH keypair
+4. Create a security group
+5. Launch an instance
+6. Associate a floating ip
+7. Log in to your instance
+
+********
+About SSH Keys
+
+OpenSSH provides several modes of authentication: password log-in, Kerberos 
+tickets and Key-based authentication. Key-based authentication is the most 
+secure method, and is therefore recommended. Other authentication methods are 
+only used in specific situations (such as setting a password when creating a 
+new instance). Ideally, password authentication should be disabled, once SSH 
+Key-based authentication is working properly.
+
+Generating a key pair provides you with two long string of characters: a “public key” and a “private key”. Anyone is allowed to see the public key, but only the owner is allowed to see the private key.
+You can place the public key on any server, and then unlock it by connecting to it with a client that already has the private key. When the two match up, the system unlocks without the need for a password. 
+You can increase security even more by protecting the private key with a passphrase.
+SSH can use either "RSA" (Rivest-Shamir-Adleman) or "DSA" ("Digital Signature Algorithm") keys. DSA is known to be less secure, so RSA is recommended. This guide uses "RSA key" and "SSH key" interchangeably.

--- a/source/ssh-filezilla-setup.rst
+++ b/source/ssh-filezilla-setup.rst
@@ -129,27 +129,28 @@ Change the read/write permissions of the folder:
 
 .. code-block:: bash
 
-$ sudo chmod 700 ~/.ssh
+  $ sudo chmod 700 ~/.ssh
 
 Check to see of any Key Pair files already exist: 
 
 .. code-block:: bash
 
-$ ls -l
+  $ ls -l
 
 If the files id_rsa and id_rsa.pub already exist, and you’re not sure 
 what they are for, you should probably make copies or backups before proceeding:
 
 .. code-block:: bash
 
-$ cp id_rsa.pub id_rsa.pub.bak
-$ cp id_rsa id_rsa.bak
+  $ cp id_rsa.pub id_rsa.pub.bak
+  $ cp id_rsa id_rsa.bak
 
 Now generate the new RSA Key Pair, using the default name:
 
 .. code-block:: bash
 
-$ ssh-keygen -t rsa
+  $ ssh-keygen -t rsa
+
 
 Option: Create unique key file names
 =====================================
@@ -162,7 +163,7 @@ Create a unique name using the -f flag:
 
 .. code-block:: bash
 
-$ ssh-keygen -t rsa -f newKeyName
+  $ ssh-keygen -t rsa -f newKeyName
 
 
 Option: Set Key Encryption Level
@@ -173,7 +174,7 @@ making it harder to crack the key by brute force methods.
 
 .. code-block:: bash
 
-$ ssh-keygen -t rsa -b 4096
+  $ ssh-keygen -t rsa -b 4096
 
 
 Finishing Off
@@ -185,14 +186,14 @@ Ensure ssh-agent is enabled by starting the ssh-agent in the background:
 
 .. code-block:: bash
 
-$ eval "$(ssh-agent -s)"
-Agent pid 59566
+  $ eval "$(ssh-agent -s)"
+  Agent pid 59566
 
 Now Add your new SSH key to the ssh-agent.
 
 .. code-block:: bash
 
-$ ssh-add ~/.ssh/id_rsa
+  $ ssh-add ~/.ssh/id_rsa
 
 If you used an existing SSH key rather than generating a new SSH key, 
 you'll need to replace "id_rsa" in the command with the name of your 
@@ -207,7 +208,8 @@ Once you have entered the keygen command, you will get this response (with your 
 
 .. code-block:: BASH
 
-Enter file in which to save the key (/home/(username)/.ssh/id_rsa):
+  Enter file in which to save the key (/home/(username)/.ssh/id_rsa):
+
 
 This provides a default file path and filename, where SSH will automatically 
 look for your private key when you are using it to log in. You can press enter 
@@ -220,13 +222,15 @@ SSH will now ask for a passphrase:
 
 .. code-block:: BASH
 
-Enter passphrase (empty for no passphrase):
+  Enter passphrase (empty for no passphrase):
+
 
 You can press enter, to continue without a passphrase, or type in a passphrase. 
 
 Entering a passphrase increases the level of security. If one of your machines is compromised, 
 the bad guys can’t log in to your server until they figure out the passphrase. This buys you 
 more time to log-in the server from another machine and change the compromised key pair.
+
 
 Choosing a good passphrase
 ==========================

--- a/source/ssh-filezilla-setup.rst
+++ b/source/ssh-filezilla-setup.rst
@@ -488,6 +488,12 @@ specific reason not to.
 To disable password authentication
 ==================================
 
+Once you have copied your SSH keys unto your server and ensured that you can 
+log in with the SSH keys alone, you can go ahead and restrict the root login 
+to only be permitted via SSH keys.
+
+In order to do this, log in to your instance.
+
 First, make a backup of your ``sshd_config`` file by copying it to your home directory, 
 or by making a read-only copy in ``/etc/ssh`` by doing:
 
@@ -496,59 +502,86 @@ or by making a read-only copy in ``/etc/ssh`` by doing:
   $ sudo cp /etc/ssh/sshd_config /etc/ssh/sshd_config.factory-defaults
   $ sudo chmod a-w /etc/ssh/sshd_config.factory-defaults
   
-Creating a read-only backup in ``/etc/ssh`` means you'll always be able to find a 
-known-good configuration when you need it.
-
-Once you've backed up your ``sshd_config`` file, you can make changes with the nano text editor, for example; 
+Then open up the SSH config file with nano:
 
 .. code-block:: bash
 
- $ sudo nano /etc/ssh/sshd_config
- 
-Now look for the following line in your ``sshd_config`` file:
+  $ sudo nano /etc/ssh/sshd_config
+
+Find the line that includes **PermitRootLogin** and modify it to ensure that users can only connect with their SSH key:
+
+.. code-block:: bash
+  
+  **PermitRootLogin without-password**
+
+Also look for the line:
 
 .. code-block:: bash
 
   **#PasswordAuthentication yes**
   
-Replace it with a line that looks like this:
+Replace it with:
 
 .. code-block:: bash
 
   **PasswordAuthentication no**
   
-Once you've made your changes you can apply them by saving the file then doing:
+Once you've made your changes you can save the file with ``ctrl`` + ``X``
+then entering ``Y`` to save changes.
+
+Now apply the changes by doing:
 
 .. code-block:: bash
 
-  $ sudo service ssh restart
-  
-Once you have saved the file and restarted your SSH server, you shouldn't even be asked for a password when you log in.
+  $ reload ssh
+
+Now you should never be asked for a password when you log in.
 
 *****************
 Troubleshooting
 *****************
 
 Detaching or Changing the Key on an Instance
-You cannot detach a Key from an instance, or modify it once attached.  The only way to assign a new Key Pair to an instance is to:
-Make a Snapshot of the instance
-Create a new Instance from the Snapshot
-Attach a new Key to the new instance while you are creating it
-Adding or changing a passphrase
-You can change the passphrase for an existing private key without regenerating the keypair. Just type the following command:
-$ ssh-keygen -p
+============================================
 
-# Start the SSH key creation process
-Enter file in which the key is (/Users/you/.ssh/id_rsa): [Hit enter]
-Key has comment '/Users/you/.ssh/id_rsa'
-Enter new passphrase (empty for no passphrase): [Type new passphrase]
-Enter same passphrase again: [Type it again]
-Your identification has been saved with the new passphrase.
+You cannot detach a Key from an instance, or modify it once attached.  
+The only way to assign a new Key Pair to an instance is to:
+
+* Make a Snapshot of the instance
+* Create a new Instance from the Snapshot
+* Attach a new Key to the new instance while you are creating it
+
+Adding or changing a passphrase
+===============================
+
+You can change the passphrase for an existing private key without regenerating the keypair. 
+Just type the following command:
+
+.. code-block:: bash
+ $ ssh-keygen -p
+
+.. code-block:: bash
+ # Start the SSH key creation process
+ Enter file in which the key is (/Users/you/.ssh/id_rsa): [Hit enter]
+ Key has comment '/Users/you/.ssh/id_rsa'
+ Enter new passphrase (empty for no passphrase): [Type new passphrase]
+ Enter same passphrase again: [Type it again]
+ Your identification has been saved with the new passphrase.
 
 If your key already has a passphrase, you will be prompted to enter it before you can change to a new passphrase.
+
 Encrypted Home Directory
-If you have an encrypted home directory, SSH cannot access your authorized_keys file because it is inside your encrypted home directory and won't be available until after you are authenticated. Therefore, SSH will default to password authentication.
-To solve this, create a folder outside your home named /etc/ssh/<username> (replace "<username>" with your actual username). This directory should have 755 permissions and be owned by the user. Move the authorized_keys file into it. The authorized_keys file should have 644 permissions and be owned by the user. 
+========================
+
+If you have an encrypted home directory, SSH cannot access your authorized_keys 
+file because it is inside your encrypted home directory and won't be available 
+until after you are authenticated. Therefore, SSH will default to password authentication.
+
+To solve this, create a folder outside your home named /etc/ssh/<username> 
+(replace "<username>" with your actual username). This directory should have 755 permissions 
+and be owned by the user. Move the authorized_keys file into it. The authorized_keys file 
+should have 644 permissions and be owned by the user.
+
 Then edit your /etc/ssh/sshd_config and add:
 AuthorizedKeysFile    /etc/ssh/%u/authorized_keys
 Finally, restart ssh with:
@@ -572,7 +605,9 @@ Error: Agent admitted failure to sign using the key.
 This error occurs when the ssh-agent on the client is not yet managing the key. Issue the following commands to fix: 
 ssh-add
 This command should be entered after you have copied your public key to the host computer.
+
 Remote Host Identification Has Changed
+======================================
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 @    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@

--- a/source/ssh-filezilla-setup.rst
+++ b/source/ssh-filezilla-setup.rst
@@ -181,6 +181,9 @@ making it harder to crack the key by brute force methods.
   $ ssh-keygen -t rsa -b 4096
 
 
+Save to location
+=================
+
 Once you have entered the keygen command, you will get this response (with your username in it):
 
 .. code-block:: bash
@@ -194,6 +197,10 @@ If you specify another folder, you will need to enter its file path when you
 issue a log in command (explained below).  You may want to use different folders
 to store the Key Pair files for different projects or instances.
 
+
+Enter a passphrase
+===================
+
 SSH will now ask for a passphrase:
 
 .. code-block:: BASH
@@ -202,23 +209,22 @@ SSH will now ask for a passphrase:
 
 You can press enter, to continue without a passphrase, or type in a passphrase. 
 
-Entering a passphrase increases the level of security. If one of your machines is compromised, 
-the bad guys can’t log in to your server until they figure out the passphrase. This buys you 
-more time to log-in the server from another machine and change the compromised key pair.
+There are a few things you should know:
 
-Choosing a good passphrase
-==========================
+* Entering a passphrase increases the level of security. If one of your machines is compromised, 
+  the bad guys can’t log in to your server until they figure out the passphrase. This buys you 
+  more time to log-in the server from another machine and change the compromised key pair.
 
-Your SSH key passphrase is only used to protect your “private key” from thieves. 
-It's never transmitted over the Internet, and the strength of your key has nothing to do 
-with the strength of your passphrase.
+* Your SSH key passphrase is only used to protect your “private key” from thieves. 
+  It's never transmitted over the Internet, and the strength of your key has nothing to do 
+  with the strength of your passphrase.
 
-There is no way to recover a lost passphrase. If the passphrase is lost or forgotten, 
-a new key must be generated and the corresponding public key copied to other machines.
+* There is no way to recover a lost passphrase. If the passphrase is lost or forgotten, 
+  a new key must be generated and the corresponding public key copied to other machines.
 
 If you use a passphrase, pick a strong one and store it securely in a password manager, 
-or write it down on a piece of paper and keep it in a secure place. Obviously, you should 
-not store it on the client machine that you are using to connect to your server.
+or keep a copy in a secure place. Obviously, you should not store it on the client machine 
+that you are using to connect to your server. Especially if it is a laptop.
 
 
 Key Pair Generated successfully

--- a/source/ssh-filezilla-setup.rst
+++ b/source/ssh-filezilla-setup.rst
@@ -168,15 +168,16 @@ You will want to add a new and unique key file name if you are making more
 than one set of keys, to access different projects or instances. 
 
 
-Option: Set Key Encryption Level
-====================================
+.. note::
 
-The default key is 2048 bits. You can increase this to 4096 bits with the -b flag, 
-making it harder to crack the key by brute force methods.
+  **Set Key Encryption Level**
 
-.. code-block:: bash
+  The default key is 2048 bits. You can increase this to 4096 bits with the -b flag, 
+  making it harder to crack the key by brute force methods.
 
-  $ ssh-keygen -t rsa -b 4096
+  .. code-block:: bash
+
+    $ ssh-keygen -t rsa -b 4096
 
 
 Once you have entered the keygen command, you will get this response (with your username in it):

--- a/source/ssh-filezilla-setup.rst
+++ b/source/ssh-filezilla-setup.rst
@@ -21,22 +21,29 @@ encrypted connection.
 This section assumes You have a Catalyst Cloud account, and you're 
 preparing to create your first instance.
 
-It is verbose: written for a relative "newbie", who may not have set 
-up an SSH connection to a remote server before, but has some expience with
+This guide is verbose: it's written for a relative "newbie", who has not set 
+up an SSH connection to a remote server before, but has some experience with
 the command line interface (terminal).
 
 The steps required to establish an encrypted SSH connection are:
 
-1. Install an configure OpenSSH
-2. Create a Router
-3. Upload an SSH keypair
-4. Create a security group
-5. Launch an instance
-6. Associate a floating ip
-7. Log in to your instance
+1. Check that you have OpenSSH
+2. Create an RSA Key Pair
+3. Securely store the Key Pair and Passphrase
+4. Upload the Public Key to a cloud server
+5. Connect to the cloud server
+6. Set-up FileZilla with your SSH key
 
-********
+Before we get going, there is a subsection which explains
+why we use RSA key pairs to make secure connections over 
+the internet.
+
+The last section is a Trouble-shooting guide, if things
+don't work exacctly as expected.
+
+**************
 About SSH Keys
+**************
 
 OpenSSH provides several modes of authentication: password log-in, Kerberos 
 tickets and Key-based authentication. Key-based authentication is the most 
@@ -45,7 +52,16 @@ only used in specific situations (such as setting a password when creating a
 new instance). Ideally, password authentication should be disabled, once SSH 
 Key-based authentication is working properly.
 
-Generating a key pair provides you with two long string of characters: a “public key” and a “private key”. Anyone is allowed to see the public key, but only the owner is allowed to see the private key.
-You can place the public key on any server, and then unlock it by connecting to it with a client that already has the private key. When the two match up, the system unlocks without the need for a password. 
+Generating a key pair provides you with two long string of characters: 
+a “public key” and a “private key”. Anyone is allowed to see the public key, 
+but only the owner is allowed to see the private key.
+You can place the public key on any server, and then unlock it by connecting 
+to it with a client that already has the private key. When the two match up, 
+the system unlocks without the need for a password. 
 You can increase security even more by protecting the private key with a passphrase.
-SSH can use either "RSA" (Rivest-Shamir-Adleman) or "DSA" ("Digital Signature Algorithm") keys. DSA is known to be less secure, so RSA is recommended. This guide uses "RSA key" and "SSH key" interchangeably.
+SSH can use either "RSA" (Rivest-Shamir-Adleman) or "DSA" ("Digital Signature Algorithm") keys. 
+DSA is known to be less secure, so RSA is recommended: this guide uses "RSA key" 
+and "SSH key" interchangeably.
+
+
+

--- a/source/ssh-filezilla-setup.rst
+++ b/source/ssh-filezilla-setup.rst
@@ -1,4 +1,4 @@
-.. _setting-up-local-connections:
+.. _ssh-filezilla-setup:
 
 ################################################
 Setting up SSH and Filezilla connections locally
@@ -112,7 +112,7 @@ Finally run the checks above, to make sure it's working.
 
 ******************************************
  Step 2: Create an RSA Key Pair
- ******************************************
+******************************************
  
 Create the key pair on the client machine (your computer). 
 Open a terminal and go to your SSH folder by typing:
@@ -171,6 +171,10 @@ making it harder to crack the key by brute force methods.
 
 $ ssh-keygen -t rsa -b 4096
 
+
+Finishing Off
+====================================
+
 Add your SSH key to the ssh-agent
 
 Ensure ssh-agent is enabled by starting the ssh-agent in the background:
@@ -189,3 +193,98 @@ $ ssh-add ~/.ssh/id_rsa
 If you used an existing SSH key rather than generating a new SSH key, 
 you'll need to replace "id_rsa" in the command with the name of your 
 existing private key file.
+
+
+******************************************
+ Step 3: Store the Keys and Passphrase
+******************************************
+
+Once you have entered the keygen command, you will get this response (with your username in it):
+
+.. code-block:: BASH
+
+Enter file in which to save the key (/home/(username)/.ssh/id_rsa):
+
+This provides a default file path and filename, where SSH will automatically 
+look for your private key when you are using it to log in. You can press enter 
+here, saving the file to the default folder. 
+
+If you specify another folder, you will need to enter its file path when you 
+issue a log-in command (explained below).
+
+SSH will now ask for a passphrase:
+
+.. code-block:: BASH
+
+Enter passphrase (empty for no passphrase):
+
+You can press enter, to continue without a passphrase, or type in a passphrase. 
+
+Entering a passphrase increases the level of security. If one of your machines is compromised, 
+the bad guys can’t log in to your server until they figure out the passphrase. This buys you 
+more time to log-in the server from another machine and change the compromised key pair.
+
+Choosing a good passphrase
+==========================
+
+Your SSH key passphrase is only used to protect your “private key” from thieves. 
+It's never transmitted over the Internet, and the strength of your key has nothing to do 
+with the strength of your passphrase.
+
+There is no way to recover a lost passphrase. If the passphrase is lost or forgotten, 
+a new key must be generated and the corresponding public key copied to other machines.
+
+If you use a passphrase, pick a strong one and store it securely in a password manager, 
+or write it down on a piece of paper and keep it in a secure place. Obviously, you should 
+not store it on the client machine that you are using to connect to your server!
+
+
+Key Pair Generated successfully
+===============================
+
+The entire key generation process will look something like this in your terminal:
+
+.. code-block:: BASH
+
+  ssh-keygen -t rsa
+  Generating public/private rsa key pair.
+  Enter file in which to save the key (/home/(user)/.ssh/id_rsa): 
+  Enter passphrase (empty for no passphrase): 
+  Enter same passphrase again: 
+  Your identification has been saved in /home/(user)/.ssh/id_rsa.
+  Your public key has been saved in /home/(user)/.ssh/id_rsa.pub.
+  The key fingerprint is:
+  4a:dd:0a:c6:35:4e:3f:ed:27:38:8c:74:44:4d:93:67 (user)@(machine)
+  The key's randomart image is:
+  +--[ RSA 2048]----+
+  |          .oo.   |
+  |         .  o.E  |
+  |        + .  o   |
+  |     . = = .     |
+  |      = S = .    |
+  |     o + = +     |
+  |      . o + o .  |
+  |           . o   |
+  |                 |
+  +-----------------+
+
+
+If you created the keys with the default name, then:
+
+The public key is now located in ``/home/(user)/.ssh/id_rsa.pub``
+The private key is now located in ``/home/(user)/.ssh/id_rsa``
+
+If you created the keys with a unique name, then:
+
+The public key is now located in ``/home/(user)/.ssh/myNewKeyName.pub``
+The private key is now located in ``/home/(user)/.ssh/myNewKeyName``
+
+
+Securing your new key pair
+==========================
+
+To use your new key pair, you need to make it available to your ssh client.  
+Change permissions to 600:
+$ cd ~/.ssh
+$ chmod 600 KEY_NAME.pem
+

--- a/source/ssh-filezilla-setup.rst
+++ b/source/ssh-filezilla-setup.rst
@@ -151,18 +151,32 @@ It is probably wiser to do this if the files id_rsa and id_rsa.pub already exist
 
 Create a unique name using the -f flag:
 
+.. code-block:: bash
+
 $ ssh-keygen -t rsa -f newKeyName
 
 Option: Set Key Encryption Level
 ====================================
-The default key is 2048 bits. You can increase this to 4096 bits with the -b flag, making it harder to crack the key by brute force methods.
+
+The default key is 2048 bits. You can increase this to 4096 bits with the -b flag, 
+making it harder to crack the key by brute force methods.
+
+.. code-block:: bash
 $ ssh-keygen -t rsa -b 4096
+
 Add your SSH key to the ssh-agent
+
 Ensure ssh-agent is enabled by starting the ssh-agent in the background:
+
+.. code-block:: bash
 $ eval "$(ssh-agent -s)"
 Agent pid 59566
-Now Add your new SSH key to the ssh-agent. 
+
+Now Add your new SSH key to the ssh-agent.
+
+.. code-block:: bash
 $ ssh-add ~/.ssh/id_rsa
 
-
-If you used an existing SSH key rather than generating a new SSH key, you'll need to replace id_rsa in the command with the name of your existing private key file.
+If you used an existing SSH key rather than generating a new SSH key, 
+you'll need to replace "id_rsa" in the command with the name of your 
+existing private key file.

--- a/source/ssh-filezilla-setup.rst
+++ b/source/ssh-filezilla-setup.rst
@@ -167,17 +167,15 @@ OR generate a new Key Pair with a unique name using the -f flag:
 You will want to add a new and unique key file name if you are making more 
 than one set of keys, to access different projects or instances. 
 
-
 .. note::
 
   **Set Key Encryption Level**
-
   The default key is 2048 bits. You can increase this to 4096 bits with the -b flag, 
   making it harder to crack the key by brute force methods.
 
-  .. code-block:: bash
+.. code-block:: bash
 
-    $ ssh-keygen -t rsa -b 4096
+  $ ssh-keygen -t rsa -b 4096
 
 
 Once you have entered the keygen command, you will get this response (with your username in it):

--- a/source/ssh-filezilla-setup.rst
+++ b/source/ssh-filezilla-setup.rst
@@ -26,12 +26,12 @@ The steps required to establish an encrypted SSH connection are:
 
 1. Check that you have OpenSSH
 2. Create an RSA Key Pair
-3. Securely store the Key Pair and Passphrase
+3. Finish off by securing your key
 4. Upload the Public Key to a cloud server
 5. Connect to the cloud server
 6. Set-up FileZilla with your SSH key
 
-Before we get going, there is a subsection which explains
+Before we start, there is a subsection which explains
 why we use RSA key pairs to make secure connections over 
 the internet. 
 
@@ -44,10 +44,12 @@ About SSH Keys
 
 OpenSSH provides several modes of authentication: password log-in, Kerberos 
 tickets and Key-based authentication. Key-based authentication is the most 
-secure method, and is therefore recommended. Other authentication methods are 
-only used in specific situations (such as setting a password when creating a 
-new instance). Ideally, password authentication should be disabled, once SSH 
-Key-based authentication is working properly.
+secure method, and is therefore recommended. 
+
+Other authentication methods are only used in specific situations (such as 
+setting a password log-in when creating a new instance). Ideally, password 
+authentication should be disabled, once SSH your key-based authentication 
+is set up and working properly.
 
 Generating a key pair provides you with two long string of characters: 
 a “public key” and a “private key”. Anyone is allowed to see the public key, 
@@ -59,6 +61,7 @@ with a passphrase.
 
 SSH can use either "RSA" (Rivest-Shamir-Adleman) or "DSA" ("Digital Signature Algorithm") keys. 
 DSA is known to be less secure, so RSA is used in this guide.
+
 
 ******************************************
 Step 1: Check that SSH is installed and running 
@@ -111,7 +114,7 @@ Now restart your computer, or start OpenSSH with the command:
   $ sudo ssh start
 
 
-Finally run the checks above, to make sure it's working.
+Now run the checks above, again, to make sure it's working.
  
 
 ******************************************
@@ -145,26 +148,21 @@ what they are for, you should probably make copies or backups before proceeding:
   $ cp id_rsa.pub id_rsa.pub.bak
   $ cp id_rsa id_rsa.bak
 
-Now generate the new RSA Key Pair, using the default name:
+Now generate the new RSA Key Pair, using the default name (id_rsa):
 
 .. code-block:: bash
 
   $ ssh-keygen -t rsa
 
-
-Option: Create unique key file names
-=====================================
-
-You will want to add a new and unique key file name if you are making more 
-than one set of keys, to access different projects or instances. 
-It is probably wiser to do this if the files id_rsa and id_rsa.pub already exist. 
-
-Create a unique name using the -f flag:
+Or you can create a unique name using the -f flag:
 
 .. code-block:: bash
 
   $ ssh-keygen -t rsa -f newKeyName
 
+You will want to add a new and unique key file name if you are making more 
+than one set of keys, to access different projects or instances. And it is 
+probably wiser to do this if the files id_rsa and id_rsa.pub already exist.
 
 Option: Set Key Encryption Level
 ====================================
@@ -177,39 +175,11 @@ making it harder to crack the key by brute force methods.
   $ ssh-keygen -t rsa -b 4096
 
 
-Finishing Off
-====================================
-
-Add your SSH key to the ssh-agent
-
-Ensure ssh-agent is enabled by starting the ssh-agent in the background:
-
-.. code-block:: bash
-
-  $ eval "$(ssh-agent -s)"
-  Agent pid 59566
-
-Now Add your new SSH key to the ssh-agent.
-
-.. code-block:: bash
-
-  $ ssh-add ~/.ssh/id_rsa
-
-If you used an existing SSH key rather than generating a new SSH key, 
-you'll need to replace "id_rsa" in the command with the name of your 
-existing private key file.
-
-
-******************************************
- Step 3: Store the Keys and Passphrase
-******************************************
-
 Once you have entered the keygen command, you will get this response (with your username in it):
 
 .. code-block:: BASH
 
   Enter file in which to save the key (/home/(username)/.ssh/id_rsa):
-
 
 This provides a default file path and filename, where SSH will automatically 
 look for your private key when you are using it to log in. You can press enter 
@@ -224,13 +194,11 @@ SSH will now ask for a passphrase:
 
   Enter passphrase (empty for no passphrase):
 
-
 You can press enter, to continue without a passphrase, or type in a passphrase. 
 
 Entering a passphrase increases the level of security. If one of your machines is compromised, 
 the bad guys can’t log in to your server until they figure out the passphrase. This buys you 
 more time to log-in the server from another machine and change the compromised key pair.
-
 
 Choosing a good passphrase
 ==========================
@@ -277,6 +245,34 @@ The entire key generation process will look something like this in your terminal
   +-----------------+
 
 
+******************************************
+ Step 3: Finishing off
+******************************************
+
+There are a few final steps to make sure your SSH connection
+will work properly the ffirst time.
+
+Add your SSH key to the ssh-agent
+====================================
+
+First, ensure ``ssh-agent`` is enabled by starting the ssh-agent in the background.
+If it is working, you will get an ``Agent pid`` response:
+
+.. code-block:: bash
+
+  $ eval "$(ssh-agent -s)"
+  Agent pid 59566
+
+Now, add your new SSH key to the ssh-agent:
+
+.. code-block:: bash
+
+  $ ssh-add ~/.ssh/newKeyName
+
+
+Locating your new public and private keys
+=========================================
+
 If you created the keys with the default name, then:
 
 The public key is now located in ``/home/(user)/.ssh/id_rsa.pub``
@@ -291,8 +287,16 @@ The private key is now located in ``/home/(user)/.ssh/myNewKeyName``
 Securing your new key pair
 ==========================
 
-To use your new key pair, you need to make it available to your ssh client.  
-Change permissions to 600:
-$ cd ~/.ssh
-$ chmod 600 KEY_NAME.pem
+Change the file permissions on your private key to make sure other
+users won't have access to it
 
+.. code-block:: bash
+
+  $ cd ~/.ssh
+  $ chmod 600 myNewKey
+
+
+.. note:: 
+
+  If you fail to do this, you may get an error when you try to use the
+  key: ``Permissions... are too open. This private key will be ignored''

--- a/source/ssh-filezilla-setup.rst
+++ b/source/ssh-filezilla-setup.rst
@@ -1,7 +1,7 @@
 .. _ssh-filezilla-setup:
 
 ################################################
-Setting up SSH and Filezilla connections locally
+Setting up SSH and Filezilla on the client
 ################################################
 
 

--- a/source/ssh-filezilla-setup.rst
+++ b/source/ssh-filezilla-setup.rst
@@ -400,12 +400,15 @@ visible in the Instances list or under the Floating IPs tab in Access & Security
 
 If you have set a passphrase, you will be asked to enter the passphrase now.
 
-.. note::
+.. warning::
 
  Sometimes your machine will open a dialog box asking for your *password*.
  What it actually wants is the *passphrase* you set when creating the key pair.
- This can be disconcerting, if you were expecting to be asked for a passphrase in
- terminal window. Just enter you passphrase and continue.
+ 
+ This can be confusing if you were expecting to be asked for a passphrase in
+ terminal window. 
+ 
+ Just enter you passphrase into the dialog box and continue.
  
 You should be able to interact with this instance as you would any Ubuntu server.
 

--- a/source/ssh-filezilla-setup.rst
+++ b/source/ssh-filezilla-setup.rst
@@ -407,10 +407,8 @@ If you have set a passphrase, you will be asked to enter the passphrase now.
 
  Sometimes your machine will open a dialog box asking for your *password*.
  What it actually wants is the *passphrase* you set when creating the key pair.
- 
  This can be confusing if you were expecting to be asked for a passphrase in
  terminal window. 
- 
  Just enter you passphrase into the dialog box and continue.
  
 You should be able to interact with this instance as you would any Ubuntu server.

--- a/source/ssh-filezilla-setup.rst
+++ b/source/ssh-filezilla-setup.rst
@@ -11,14 +11,19 @@ Overview
 
 This section provides step-by-step advice on setting up a connection
 to your Catalyst Cloud instance from your local (client) machine.
-After you have completed the steps you will be able to log
-on to the server via SSH from anywhere on the internet using an SSH key.
 
-This section assumes you are a relative "newbie", who may not have set 
-up an SSH connection to a remote server before. You have a Catalyst Cloud 
-account, and you're preparing to create your first instance.  You know
-how to use the command line interface (terminal), but may not be very
-experienced with it.
+Some of the steps are required before you create a new instance
+
+After you have completed the steps you will be able to log
+on to the server via SSH from your local machine, with an strongly
+encrypted connection.
+
+This section assumes You have a Catalyst Cloud account, and you're 
+preparing to create your first instance.
+
+It is verbose: written for a relative "newbie", who may not have set 
+up an SSH connection to a remote server before, but has some expience with
+the command line interface (terminal).
 
 The steps required to establish an encrypted SSH connection are:
 


### PR DESCRIPTION
As a new user, I went through all the steps; created a new instance, SSH'ed in to it, set up a webserver, then couldn't see it on the public IP address.  All because I didn't know I needed a rule allowing ingress to port 80. Very frustrating!

Have added that advice as a note:: block, and amended the warning:: block about using CIDR 0.0.0.0/0, so this part of the set-up is much clearer and easier for other newbies.

Also added an extra line of whitespace under all the image blocks in "launch from instance", so that the text which refers to an image sits more clearly with the image below, not jammed-up against the image above.