### PR TITLE
remove Instance detection section as the issue has been fixed in shade

### DIFF
--- a/source/tutorials/ansible-openstack-dynamic-inventory.rst
+++ b/source/tutorials/ansible-openstack-dynamic-inventory.rst
@@ -311,13 +311,3 @@ example using the nova command line client:
 An Ansible playbook for creating the instances used in this example is
 available at
 https://raw.githubusercontent.com/catalyst/catalystcloud-ansible/master/example-playbooks/two-instances-with-sequence.yml
-
-Instance detection
-==================
-
-There are some quirks around which instances in an OpenStack project the
-dynamic inventory script will report:
-
-* Instances that do not have floating IPs are not included in the inventory
-* Instances that do not have SSH access due to security group rules are
-  included in the inventory


### PR DESCRIPTION
Fixed in shade:

commit c6017bdc80b6a0efdcff8202dd7d37e4155f3733
Author: Monty Taylor <mordred@inaugust.com>
Date:   Tue Apr 12 07:28:14 2016 -0500

    Honor default_network for interface_ip
    
    When we generate the interface_ip (which is used, amongst other things,
    by ansible dynamic inventory) we do our best to figure out based on
    config which of the IPs a server has should be the one that the user
    wants to be "the" interface. In the previous patches, we added support
    for the user configuring a "default_network" for one of their networks.
    If the user has done this, and the server has an IP on that network, we
    should use that network for interface_ip.
    
    Change-Id: I440916622f9dfe12f8865bb1841dd0932d3cd7d0