### PR TITLE
Update access-control.rst to use title capitalisation consistent with other titles

### DIFF
--- a/source/access-control.rst
+++ b/source/access-control.rst
@@ -1,7 +1,7 @@
 .. _access-control:
 
 ##############
-Access Control
+Access control
 ##############
 
 


### PR DESCRIPTION
This document used sentence case titles, except for in this one place. This commit fixes it.